### PR TITLE
chore: add tests, CI linting, fix lint issues

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,12 +17,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
-        go-version: "1.25"
+        go-version-file: go.mod
 
     - name: Build
       run: make build
@@ -30,12 +30,12 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
-        go-version: "1.25"
+        go-version-file: go.mod
 
     - name: Test
       run: make test
@@ -43,15 +43,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
-        go-version: "1.25"
+        go-version-file: go.mod
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v9
+      uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
       with:
         version: v2.8
         args: --timeout 5m

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,33 @@ jobs:
         go-version: "1.25"
 
     - name: Build
-      run: go build -v ./...
+      run: make build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.25"
 
     - name: Test
-      run: go test -v ./...
+      run: make test
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: "1.25"
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v9
+      with:
+        version: v2.8
+        args: --timeout 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+version: "2"
+linters:
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - funlen
+          - goconst
+          - errcheck
+          - ineffassign
+          - staticcheck
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ doc:
 	gomarkdoc ./...
 
 lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run
 
 bench:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
-.PHONY: build test doc
+.PHONY: build test doc lint bench
 build:
 	go build ./...
 
 test:
-	go test ./...
+	go test ./... -race
 
 doc:
 	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
 	gomarkdoc ./...
+
+lint:
+	golangci-lint run
+
+bench:
+	go test -bench=. -benchmem ./...

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ build:
 	go build ./...
 
 test:
-	go test ./... -race
+	go test -race ./...
 
 doc:
 	go install github.com/princjef/gomarkdoc/cmd/gomarkdoc@latest
@@ -13,4 +13,4 @@ lint:
 	golangci-lint run
 
 bench:
-	go test -bench=. -benchmem ./...
+	go test -run=^$ -bench=. -benchmem ./...

--- a/tracing.go
+++ b/tracing.go
@@ -235,6 +235,7 @@ func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.
 func traceHTTPHeaders(ctx context.Context, sp opentracing.Span, hdr http.Header) {
 	// Transmit the span's TraceContext as HTTP headers on our
 	// outbound request.
+	// Best-effort trace propagation — inject errors are non-fatal
 	_ = opentracing.GlobalTracer().Inject(
 		sp.Context(),
 		opentracing.HTTPHeaders,
@@ -301,8 +302,11 @@ func GRPCTracingSpan(operationName string, ctx context.Context) context.Context 
 
 	var span opentracing.Span
 	wireContext, err := tracer.Extract(opentracing.TextMap, metadataReaderWriter{&md})
-	_ = err
-	span = tracer.StartSpan(operationName, otext.RPCServerOption(wireContext))
+	if err != nil {
+		span = tracer.StartSpan(operationName)
+	} else {
+		span = tracer.StartSpan(operationName, otext.RPCServerOption(wireContext))
+	}
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	ctx = metadata.NewOutgoingContext(ctx, md)
 	return ctx

--- a/tracing.go
+++ b/tracing.go
@@ -235,7 +235,7 @@ func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.
 func traceHTTPHeaders(ctx context.Context, sp opentracing.Span, hdr http.Header) {
 	// Transmit the span's TraceContext as HTTP headers on our
 	// outbound request.
-	opentracing.GlobalTracer().Inject(
+	_ = opentracing.GlobalTracer().Inject(
 		sp.Context(),
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(hdr))
@@ -296,17 +296,12 @@ func GRPCTracingSpan(operationName string, ctx context.Context) context.Context 
 		md = metadata.MD{}
 	}
 	if span := opentracing.SpanFromContext(ctx); span != nil {
-		// There's nothing we can do with an error here.
-		if err := tracer.Inject(span.Context(), opentracing.TextMap, metadataReaderWriter{&md}); err != nil {
-			// log.Info(ctx, "err", err, "component", "tracing")
-		}
+		_ = tracer.Inject(span.Context(), opentracing.TextMap, metadataReaderWriter{&md})
 	}
 
 	var span opentracing.Span
 	wireContext, err := tracer.Extract(opentracing.TextMap, metadataReaderWriter{&md})
-	if err != nil && err != opentracing.ErrSpanContextNotFound {
-		// log.Info(ctx, "err", err, "component", "tracing")
-	}
+	_ = err
 	span = tracer.StartSpan(operationName, otext.RPCServerOption(wireContext))
 	ctx = opentracing.ContextWithSpan(ctx, span)
 	ctx = metadata.NewOutgoingContext(ctx, md)

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -1,0 +1,146 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+)
+
+func TestNewInternalSpan(t *testing.T) {
+	ctx := context.Background()
+	span, newCtx := NewInternalSpan(ctx, "test-internal")
+	if span == nil {
+		t.Fatal("expected non-nil span")
+	}
+	if newCtx == nil {
+		t.Fatal("expected non-nil context")
+	}
+	// Verify the span can be ended without panic.
+	span.End()
+}
+
+func TestNewDatastoreSpan(t *testing.T) {
+	ctx := context.Background()
+	span, newCtx := NewDatastoreSpan(ctx, "redis", "GET", "users")
+	if span == nil {
+		t.Fatal("expected non-nil span")
+	}
+	if newCtx == nil {
+		t.Fatal("expected non-nil context")
+	}
+	// Set a query to exercise the datastore-specific path.
+	span.SetQuery("GET users:123")
+	span.SetTag("key", "users:123")
+	span.End()
+}
+
+func TestNewExternalSpan(t *testing.T) {
+	ctx := context.Background()
+	span, newCtx := NewExternalSpan(ctx, "other-service", "/api/v1/resource")
+	if span == nil {
+		t.Fatal("expected non-nil span")
+	}
+	if newCtx == nil {
+		t.Fatal("expected non-nil context")
+	}
+	span.SetTag("status", 200)
+	span.End()
+}
+
+func TestSpanNilSafety(t *testing.T) {
+	var span *tracingSpan
+
+	// All methods on a nil *tracingSpan should be safe to call.
+	span.End()
+	span.Finish()
+	span.SetTag("key", "value")
+	span.SetQuery("SELECT 1")
+
+	err := span.SetError(errors.New("some error"))
+	if err == nil {
+		t.Fatal("expected SetError to return the provided error even on nil span")
+	}
+
+	// SetError with nil error should also be safe.
+	err = span.SetError(nil)
+	if err != nil {
+		t.Fatal("expected SetError(nil) to return nil")
+	}
+}
+
+func TestMetadataReaderWriter(t *testing.T) {
+	md := metadata.MD{}
+	rw := metadataReaderWriter{&md}
+
+	// Test Set with a normal key.
+	rw.Set("X-Request-ID", "abc123")
+	vals := md["x-request-id"]
+	if len(vals) != 1 || vals[0] != "abc123" {
+		t.Fatalf("expected [abc123], got %v", vals)
+	}
+
+	// Test Set with a "-bin" suffix key triggers base64 encoding.
+	rw.Set("X-Data-Bin", "hello")
+	vals = md["x-data-bin"]
+	if len(vals) != 1 || vals[0] != "aGVsbG8=" {
+		t.Fatalf("expected [aGVsbG8=] for bin key, got %v", vals)
+	}
+
+	// Test that Set appends on repeated calls.
+	rw.Set("X-Request-ID", "def456")
+	vals = md["x-request-id"]
+	if len(vals) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(vals))
+	}
+
+	// Test ForeachKey iterates all key-value pairs.
+	collected := make(map[string][]string)
+	err := rw.ForeachKey(func(key, val string) error {
+		collected[key] = append(collected[key], val)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error from ForeachKey: %v", err)
+	}
+	if len(collected["x-request-id"]) != 2 {
+		t.Fatalf("expected 2 values for x-request-id, got %d", len(collected["x-request-id"]))
+	}
+	if len(collected["x-data-bin"]) != 1 {
+		t.Fatalf("expected 1 value for x-data-bin, got %d", len(collected["x-data-bin"]))
+	}
+
+	// Test ForeachKey propagates handler errors.
+	expectedErr := errors.New("stop")
+	err = rw.ForeachKey(func(key, val string) error {
+		return expectedErr
+	})
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected ForeachKey to return handler error, got %v", err)
+	}
+}
+
+func TestClientSpan(t *testing.T) {
+	ctx := context.Background()
+	newCtx, span := ClientSpan("child-operation", ctx)
+	if span == nil {
+		t.Fatal("expected non-nil span from ClientSpan")
+	}
+	if newCtx == nil {
+		t.Fatal("expected non-nil context from ClientSpan")
+	}
+	span.Finish()
+
+	// Test with an existing parent span in context.
+	ctxWithSpan, parentSpan := ClientSpan("parent-operation", ctx)
+	childCtx, childSpan := ClientSpan("child-of-parent", ctxWithSpan)
+	if childSpan == nil {
+		t.Fatal("expected non-nil child span")
+	}
+	if childCtx == nil {
+		t.Fatal("expected non-nil child context")
+	}
+	childSpan.Finish()
+	parentSpan.Finish()
+}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -144,3 +144,20 @@ func TestClientSpan(t *testing.T) {
 	childSpan.Finish()
 	parentSpan.Finish()
 }
+
+func TestGRPCTracingSpan(t *testing.T) {
+	ctx := context.Background()
+	// Test with no existing span in context
+	newCtx := GRPCTracingSpan("test-operation", ctx)
+	if newCtx == nil {
+		t.Fatal("expected non-nil context")
+	}
+
+	// Test with existing span in context (via ClientSpan)
+	ctxWithSpan, span := ClientSpan("parent-op", ctx)
+	defer span.Finish()
+	newCtx2 := GRPCTracingSpan("child-operation", ctxWithSpan)
+	if newCtx2 == nil {
+		t.Fatal("expected non-nil context with parent span")
+	}
+}


### PR DESCRIPTION
## Summary
- Add unit tests for spans, nil safety, and metadata reader/writer
- Fix unchecked `Inject()` error and empty branches
- Add golangci-lint config and CI lint job
- Add `-race` flag to test target
- Standardize CI with separate build/test/lint jobs

## Test plan
- [x] `make build` passes
- [x] `make test` passes (with -race)
- [x] `make lint` passes with 0 issues