### PR TITLE
docs: regenerate README from updated source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![GoDoc](https://img.shields.io/badge/pkg.go.dev-doc-blue)](http://pkg.go.dev/github.com/go-coldbrew/tracing)
 
+
+
 # tracing
 
 ```go
@@ -12,20 +14,21 @@ Package tracing is a library that provides distributed tracing to Go application
 
 ## Index
 
-- [func ClientSpan(operationName string, ctx context.Context) (context.Context, opentracing.Span)](<#func-clientspan>)
-- [func CloneContextValues(parent context.Context) context.Context](<#func-clonecontextvalues>)
-- [func GRPCTracingSpan(operationName string, ctx context.Context) context.Context](<#func-grpctracingspan>)
-- [func MergeContextValues(parent context.Context, main context.Context) context.Context](<#func-mergecontextvalues>)
-- [func MergeParentContext(parent context.Context, main context.Context) context.Context](<#func-mergeparentcontext>)
-- [func NewContextWithParentValues(parent context.Context) context.Context](<#func-newcontextwithparentvalues>)
-- [type Span](<#type-span>)
-  - [func NewDatastoreSpan(ctx context.Context, datastore, operation, collection string) (Span, context.Context)](<#func-newdatastorespan>)
-  - [func NewExternalSpan(ctx context.Context, name string, url string) (Span, context.Context)](<#func-newexternalspan>)
-  - [func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.Header) (Span, context.Context)](<#func-newhttpexternalspan>)
-  - [func NewInternalSpan(ctx context.Context, name string) (Span, context.Context)](<#func-newinternalspan>)
+- [func ClientSpan\(operationName string, ctx context.Context\) \(context.Context, opentracing.Span\)](<#ClientSpan>)
+- [func CloneContextValues\(parent context.Context\) context.Context](<#CloneContextValues>)
+- [func GRPCTracingSpan\(operationName string, ctx context.Context\) context.Context](<#GRPCTracingSpan>)
+- [func MergeContextValues\(parent context.Context, main context.Context\) context.Context](<#MergeContextValues>)
+- [func MergeParentContext\(parent context.Context, main context.Context\) context.Context](<#MergeParentContext>)
+- [func NewContextWithParentValues\(parent context.Context\) context.Context](<#NewContextWithParentValues>)
+- [type Span](<#Span>)
+  - [func NewDatastoreSpan\(ctx context.Context, datastore, operation, collection string\) \(Span, context.Context\)](<#NewDatastoreSpan>)
+  - [func NewExternalSpan\(ctx context.Context, name string, url string\) \(Span, context.Context\)](<#NewExternalSpan>)
+  - [func NewHTTPExternalSpan\(ctx context.Context, name string, url string, hdr http.Header\) \(Span, context.Context\)](<#NewHTTPExternalSpan>)
+  - [func NewInternalSpan\(ctx context.Context, name string\) \(Span, context.Context\)](<#NewInternalSpan>)
 
 
-## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L227>)
+<a name="ClientSpan"></a>
+## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L272>)
 
 ```go
 func ClientSpan(operationName string, ctx context.Context) (context.Context, opentracing.Span)
@@ -33,6 +36,7 @@ func ClientSpan(operationName string, ctx context.Context) (context.Context, ope
 
 ClientSpan starts a new client span linked to the existing spans if any are found in the context. The returned context should be used in place of the original
 
+<a name="CloneContextValues"></a>
 ## func [CloneContextValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L24>)
 
 ```go
@@ -41,7 +45,8 @@ func CloneContextValues(parent context.Context) context.Context
 
 CloneContextValues clones a given context values and returns a new context obj which is not affected by Cancel, Deadline etc Deprecated: The function name is a bit confusing, use CloneContextValues instead
 
-## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L245>)
+<a name="GRPCTracingSpan"></a>
+## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L290>)
 
 ```go
 func GRPCTracingSpan(operationName string, ctx context.Context) context.Context
@@ -49,6 +54,7 @@ func GRPCTracingSpan(operationName string, ctx context.Context) context.Context
 
 GRPCTracingSpan starts a new client span linked to the existing spans if any are found in the context. The returned context should be used in place of the original
 
+<a name="MergeContextValues"></a>
 ## func [MergeContextValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L45>)
 
 ```go
@@ -57,6 +63,7 @@ func MergeContextValues(parent context.Context, main context.Context) context.Co
 
 MergeContextValues merged the given main context with a parent context, Cancel/Deadline etc are used from the main context and values are looked in both the contexts can be use to merge a parent context with a new context, the new context will have the values from both the contexts
 
+<a name="MergeParentContext"></a>
 ## func [MergeParentContext](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L39>)
 
 ```go
@@ -65,6 +72,7 @@ func MergeParentContext(parent context.Context, main context.Context) context.Co
 
 MergeParentContext merged the given main context with a parent context, Cancel/Deadline etc are used from the main context and values are looked in both the contexts Deprecated: The function name is a bit confusing, use MergeContextValues instead
 
+<a name="NewContextWithParentValues"></a>
 ## func [NewContextWithParentValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L30>)
 
 ```go
@@ -73,6 +81,7 @@ func NewContextWithParentValues(parent context.Context) context.Context
 
 NewContextWithParentValues clones a given context values and returns a new context obj which is not affected by Cancel, Deadline etc can be used to pass context values to a new context which is not affected by the parent context cancel/deadline etc from parent
 
+<a name="Span"></a>
 ## type [Span](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L19-L30>)
 
 Span defines an interface for implementing a tracing span This is used to abstract the underlying tracing implementation, currently using opentracing/opentelemetry and newrelic tracing libraries for implementation
@@ -92,7 +101,8 @@ type Span interface {
 }
 ```
 
-### func [NewDatastoreSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L126>)
+<a name="NewDatastoreSpan"></a>
+### func [NewDatastoreSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L147>)
 
 ```go
 func NewDatastoreSpan(ctx context.Context, datastore, operation, collection string) (Span, context.Context)
@@ -100,7 +110,8 @@ func NewDatastoreSpan(ctx context.Context, datastore, operation, collection stri
 
 NewDatastoreSpan starts a span for tracing data store actions This is used to trace actions against a data store, for example, a database query or a redis call
 
-### func [NewExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L178>)
+<a name="NewExternalSpan"></a>
+### func [NewExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L222>)
 
 ```go
 func NewExternalSpan(ctx context.Context, name string, url string) (Span, context.Context)
@@ -108,7 +119,8 @@ func NewExternalSpan(ctx context.Context, name string, url string) (Span, contex
 
 NewExternalSpan starts a span for tracing external actions This is used to trace actions against an external service, for example, a call to another service or a call to an external API
 
-### func [NewHTTPExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L185>)
+<a name="NewHTTPExternalSpan"></a>
+### func [NewHTTPExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L229>)
 
 ```go
 func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.Header) (Span, context.Context)
@@ -116,14 +128,13 @@ func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.
 
 NewHTTPExternalSpan starts a span for tracing external HTTP actions This is used to trace actions against an external service, for example, a call to another service or a call to an external API It also adds the HTTP headers to the span so that the external service can trace the call back to this service if needed
 
-### func [NewInternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L109>)
+<a name="NewInternalSpan"></a>
+### func [NewInternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L118>)
 
 ```go
 func NewInternalSpan(ctx context.Context, name string) (Span, context.Context)
 ```
 
 NewInternalSpan starts a span for tracing internal actions This is used to trace actions within the same service, for example, a function call within the same service
-
-
 
 Generated by [gomarkdoc](<https://github.com/princjef/gomarkdoc>)

--- a/newrelic/README.md
+++ b/newrelic/README.md
@@ -2,6 +2,8 @@
 
 [![GoDoc](https://img.shields.io/badge/pkg.go.dev-doc-blue)](http://pkg.go.dev/github.com/go-coldbrew/tracing)
 
+
+
 # newrelic
 
 ```go
@@ -11,26 +13,26 @@ import "github.com/go-coldbrew/tracing/newrelic"
 ## Index
 
 - [Variables](<#variables>)
-- [func FinishNRTransaction(ctx context.Context, err error)](<#func-finishnrtransaction>)
-- [func GetNewRelicApp() *newrelic.Application](<#func-getnewrelicapp>)
-- [func GetNewRelicTransactionFromContext(ctx context.Context) *newrelic.Transaction](<#func-getnewrelictransactionfromcontext>)
-- [func GetOrStartNew(ctx context.Context, name string) (*newrelic.Transaction, context.Context)](<#func-getorstartnew>)
-- [func IgnoreNRTransaction(ctx context.Context)](<#func-ignorenrtransaction>)
-- [func SetNewRelicApp(nr *newrelic.Application)](<#func-setnewrelicapp>)
-- [func StartNRTransaction(path string, ctx context.Context, req *http.Request, w http.ResponseWriter) context.Context](<#func-startnrtransaction>)
-- [func StoreNewRelicTransactionToContext(ctx context.Context, t *newrelic.Transaction) context.Context](<#func-storenewrelictransactiontocontext>)
+- [func FinishNRTransaction\(ctx context.Context, err error\)](<#FinishNRTransaction>)
+- [func GetNewRelicApp\(\) \*newrelic.Application](<#GetNewRelicApp>)
+- [func GetNewRelicTransactionFromContext\(ctx context.Context\) \*newrelic.Transaction](<#GetNewRelicTransactionFromContext>)
+- [func GetOrStartNew\(ctx context.Context, name string\) \(\*newrelic.Transaction, context.Context\)](<#GetOrStartNew>)
+- [func IgnoreNRTransaction\(ctx context.Context\)](<#IgnoreNRTransaction>)
+- [func SetNewRelicApp\(nr \*newrelic.Application\)](<#SetNewRelicApp>)
+- [func StartNRTransaction\(path string, ctx context.Context, req \*http.Request, w http.ResponseWriter\) context.Context](<#StartNRTransaction>)
+- [func StoreNewRelicTransactionToContext\(ctx context.Context, t \*newrelic.Transaction\) context.Context](<#StoreNewRelicTransactionToContext>)
 
 
 ## Variables
 
+<a name="NewRelicApp"></a>NewRelicApp is the reference for newrelic application
+
 ```go
-var (
-    // NewRelicApp is the reference for newrelic application
-    NewRelicApp *newrelic.Application
-)
+var NewRelicApp *newrelic.Application
 ```
 
-## func [FinishNRTransaction](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L71>)
+<a name="FinishNRTransaction"></a>
+## func [FinishNRTransaction](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L82>)
 
 ```go
 func FinishNRTransaction(ctx context.Context, err error)
@@ -38,13 +40,17 @@ func FinishNRTransaction(ctx context.Context, err error)
 
 FinishNRTransaction finishes an existing transaction if there is no transaction in the context, it does nothing
 
-## func [GetNewRelicApp](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L20>)
+<a name="GetNewRelicApp"></a>
+## func [GetNewRelicApp](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L19>)
 
 ```go
 func GetNewRelicApp() *newrelic.Application
 ```
 
-## func [GetNewRelicTransactionFromContext](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L28>)
+
+
+<a name="GetNewRelicTransactionFromContext"></a>
+## func [GetNewRelicTransactionFromContext](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L27>)
 
 ```go
 func GetNewRelicTransactionFromContext(ctx context.Context) *newrelic.Transaction
@@ -52,7 +58,8 @@ func GetNewRelicTransactionFromContext(ctx context.Context) *newrelic.Transactio
 
 GetNewRelicTransactionFromContext fetches the new relic transaction that is stored in the context if there is no transaction in the context, it returns nil
 
-## func [GetOrStartNew](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L34>)
+<a name="GetOrStartNew"></a>
+## func [GetOrStartNew](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L33>)
 
 ```go
 func GetOrStartNew(ctx context.Context, name string) (*newrelic.Transaction, context.Context)
@@ -60,7 +67,8 @@ func GetOrStartNew(ctx context.Context, name string) (*newrelic.Transaction, con
 
 GetOrStartNew returns a new relic transaction from context if there is no transaction in the context, it starts a new transaction
 
-## func [IgnoreNRTransaction](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L81>)
+<a name="IgnoreNRTransaction"></a>
+## func [IgnoreNRTransaction](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L92>)
 
 ```go
 func IgnoreNRTransaction(ctx context.Context)
@@ -68,13 +76,17 @@ func IgnoreNRTransaction(ctx context.Context)
 
 IgnoreNRTransaction ignores this NR trasaction and prevents it from being reported can be used to ignore health check transactions etc
 
-## func [SetNewRelicApp](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L16>)
+<a name="SetNewRelicApp"></a>
+## func [SetNewRelicApp](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L15>)
 
 ```go
 func SetNewRelicApp(nr *newrelic.Application)
 ```
 
-## func [StartNRTransaction](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L47>)
+
+
+<a name="StartNRTransaction"></a>
+## func [StartNRTransaction](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L49>)
 
 ```go
 func StartNRTransaction(path string, ctx context.Context, req *http.Request, w http.ResponseWriter) context.Context
@@ -82,14 +94,13 @@ func StartNRTransaction(path string, ctx context.Context, req *http.Request, w h
 
 StartNRTransaction starts a new newrelic transaction if there is already a transaction in the context, it will start a child transaction
 
-## func [StoreNewRelicTransactionToContext](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L41>)
+<a name="StoreNewRelicTransactionToContext"></a>
+## func [StoreNewRelicTransactionToContext](<https://github.com/go-coldbrew/tracing/blob/main/newrelic/newrelic.go#L43>)
 
 ```go
 func StoreNewRelicTransactionToContext(ctx context.Context, t *newrelic.Transaction) context.Context
 ```
 
 StoreNewRelicTransactionToContext stores a new relic transaction object to context if there is already a transaction in the context, it will be overwritten by the new one passed in the argument
-
-
 
 Generated by [gomarkdoc](<https://github.com/princjef/gomarkdoc>)


### PR DESCRIPTION
## Summary
- Regenerate auto-generated README via gomarkdoc to reflect recent code changes

## Test plan
- [x] README reflects current API