### PR TITLE
feat: add SupportPackageIsVersion1 compile-time version sentinel

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,6 @@
 // Package tracing is a library that provides distributed tracing to Go applications. It offers features such as collecting performance data of an application, identifying where requests are spending most of their time, and segmenting requests. It supports exporting traces to 3rd-party services such as Jaeger, Zipkin, Opentelemetry, and NewRelic. Go-Coldbrew Tracing helps developers quickly identify issues and take corrective action when performance bottlenecks occur.
 package tracing
+
+// SupportPackageIsVersion1 is a compile-time assertion constant.
+// Downstream packages reference this to enforce version compatibility.
+const SupportPackageIsVersion1 = true


### PR DESCRIPTION
## Summary
- Add `SupportPackageIsVersion1` constant following the gRPC `SupportPackageIsVersion` pattern
- Downstream packages reference this constant to enforce version compatibility at compile time
- When a breaking change is made, export a new version and remove the old one to force coordinated updates

## Test plan
- [x] `go build ./...` passes