### PR TITLE
fix: add go:fix inline directives for deprecated context helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const SupportPackageIsVersion1 = true
 ```
 
 <a name="ClientSpan"></a>
-## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L270>)
+## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L271>)
 
 ```go
 func ClientSpan(operationName string, ctx context.Context) (context.Context, oteltrace.Span)
@@ -51,16 +51,16 @@ func ClientSpan(operationName string, ctx context.Context) (context.Context, ote
 ClientSpan starts a new client span linked to the existing spans if any are found in the context. The returned context should be used in place of the original.
 
 <a name="CloneContextValues"></a>
-## func [CloneContextValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L24>)
+## func [CloneContextValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L25>)
 
 ```go
 func CloneContextValues(parent context.Context) context.Context
 ```
 
-CloneContextValues clones a given context values and returns a new context obj which is not affected by Cancel, Deadline etc Deprecated: The function name is a bit confusing, use CloneContextValues instead
+Deprecated: Use [NewContextWithParentValues](<#NewContextWithParentValues>) instead.
 
 <a name="GRPCTracingSpan"></a>
-## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L276>)
+## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L277>)
 
 ```go
 func GRPCTracingSpan(operationName string, ctx context.Context) context.Context
@@ -69,7 +69,7 @@ func GRPCTracingSpan(operationName string, ctx context.Context) context.Context
 GRPCTracingSpan starts a new server span from incoming gRPC metadata. The returned context should be used in place of the original.
 
 <a name="MergeContextValues"></a>
-## func [MergeContextValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L45>)
+## func [MergeContextValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L47>)
 
 ```go
 func MergeContextValues(parent context.Context, main context.Context) context.Context
@@ -78,16 +78,16 @@ func MergeContextValues(parent context.Context, main context.Context) context.Co
 MergeContextValues merged the given main context with a parent context, Cancel/Deadline etc are used from the main context and values are looked in both the contexts can be use to merge a parent context with a new context, the new context will have the values from both the contexts
 
 <a name="MergeParentContext"></a>
-## func [MergeParentContext](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L39>)
+## func [MergeParentContext](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L41>)
 
 ```go
 func MergeParentContext(parent context.Context, main context.Context) context.Context
 ```
 
-MergeParentContext merged the given main context with a parent context, Cancel/Deadline etc are used from the main context and values are looked in both the contexts Deprecated: The function name is a bit confusing, use MergeContextValues instead
+Deprecated: Use [MergeContextValues](<#MergeContextValues>) instead.
 
 <a name="NewContextWithParentValues"></a>
-## func [NewContextWithParentValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L30>)
+## func [NewContextWithParentValues](<https://github.com/go-coldbrew/tracing/blob/main/context.go#L31>)
 
 ```go
 func NewContextWithParentValues(parent context.Context) context.Context
@@ -107,7 +107,7 @@ type Span interface {
     // Finish ends the span, can also use End()
     Finish()
     // SetTag sets a tag on the span, can be used to add custom attributes
-    SetTag(key string, value interface{})
+    SetTag(key string, value any)
     // SetQuery sets the query on the span, can be used to add query for datastore spans
     SetQuery(query string)
     // SetError sets the error on the span

--- a/context.go
+++ b/context.go
@@ -9,7 +9,7 @@ type cloneContext struct {
 	parent          context.Context
 }
 
-func (c *cloneContext) Value(key interface{}) interface{} {
+func (c *cloneContext) Value(key any) any {
 	// look for value in new context
 	val := c.Context.Value(key)
 	if val != nil {
@@ -19,8 +19,9 @@ func (c *cloneContext) Value(key interface{}) interface{} {
 	return c.parent.Value(key)
 }
 
-// CloneContextValues clones a given context values and returns a new context obj which is not affected by Cancel, Deadline etc
-// Deprecated: The function name is a bit confusing, use CloneContextValues instead
+// Deprecated: Use [NewContextWithParentValues] instead.
+//
+//go:fix inline
 func CloneContextValues(parent context.Context) context.Context {
 	return NewContextWithParentValues(parent)
 }
@@ -34,8 +35,9 @@ func NewContextWithParentValues(parent context.Context) context.Context {
 	}
 }
 
-// MergeParentContext merged the given main context with a parent context, Cancel/Deadline etc are used from the main context and values are looked in both the contexts
-// Deprecated: The function name is a bit confusing, use MergeContextValues instead
+// Deprecated: Use [MergeContextValues] instead.
+//
+//go:fix inline
 func MergeParentContext(parent context.Context, main context.Context) context.Context {
 	return MergeContextValues(parent, main)
 }

--- a/tracing.go
+++ b/tracing.go
@@ -21,7 +21,7 @@ const tracerName = "github.com/go-coldbrew/tracing"
 
 // toAttribute converts a key-value pair to a typed OTEL attribute,
 // preserving numeric and boolean types instead of stringifying everything.
-func toAttribute(key string, value interface{}) attribute.KeyValue {
+func toAttribute(key string, value any) attribute.KeyValue {
 	switch v := value.(type) {
 	case string:
 		return attribute.String(key, v)
@@ -47,7 +47,7 @@ type Span interface {
 	// Finish ends the span, can also use End()
 	Finish()
 	// SetTag sets a tag on the span, can be used to add custom attributes
-	SetTag(key string, value interface{})
+	SetTag(key string, value any)
 	// SetQuery sets the query on the span, can be used to add query for datastore spans
 	SetQuery(query string)
 	// SetError sets the error on the span
@@ -90,7 +90,7 @@ func (span *tracingSpan) Finish() {
 	span.End()
 }
 
-func (span *tracingSpan) SetTag(key string, value interface{}) {
+func (span *tracingSpan) SetTag(key string, value any) {
 	if span == nil {
 		return
 	}


### PR DESCRIPTION
## Summary

Add `//go:fix inline` directives to deprecated functions so `go fix` automatically rewrites call sites:

- `CloneContextValues(parent)` → `NewContextWithParentValues(parent)`
- `MergeParentContext(parent, main)` → `MergeContextValues(parent, main)`

Users can run `go fix ./...` to automatically migrate.

Also applies `go fix` suggestions: `interface{}` → `any` throughout the package.

## Test plan
- [x] `go test -race ./...` — passes
- [x] `make lint` — 0 issues
- [x] `go fix -diff ./...` — produces expected rewrites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation with clearer deprecation notices and explicit guidance on recommended replacements.
  * Modernized type signatures in the public API to use contemporary Go conventions.
  * Corrected anchor references in API documentation for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->