### PR TITLE
refactor: adopt OTel semconv v1.40.0 for datastore and external spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const SupportPackageIsVersion1 = true
 ```
 
 <a name="ClientSpan"></a>
-## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L271>)
+## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L275>)
 
 ```go
 func ClientSpan(operationName string, ctx context.Context) (context.Context, oteltrace.Span)
@@ -60,7 +60,7 @@ func CloneContextValues(parent context.Context) context.Context
 Deprecated: Use [NewContextWithParentValues](<#NewContextWithParentValues>) instead.
 
 <a name="GRPCTracingSpan"></a>
-## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L277>)
+## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L281>)
 
 ```go
 func GRPCTracingSpan(operationName string, ctx context.Context) context.Context
@@ -96,7 +96,7 @@ func NewContextWithParentValues(parent context.Context) context.Context
 NewContextWithParentValues clones a given context values and returns a new context obj which is not affected by Cancel, Deadline etc can be used to pass context values to a new context which is not affected by the parent context cancel/deadline etc from parent
 
 <a name="Span"></a>
-## type [Span](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L44-L55>)
+## type [Span](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L45-L56>)
 
 Span defines an interface for implementing a tracing span. Consumers use this to create and annotate spans without coupling to a specific tracing backend.
 
@@ -116,7 +116,7 @@ type Span interface {
 ```
 
 <a name="NewDatastoreSpan"></a>
-### func [NewDatastoreSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L168>)
+### func [NewDatastoreSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L169>)
 
 ```go
 func NewDatastoreSpan(ctx context.Context, datastore, operation, collection string) (Span, context.Context)
@@ -154,7 +154,7 @@ func main() {
 </details>
 
 <a name="NewExternalSpan"></a>
-### func [NewExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L247>)
+### func [NewExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L251>)
 
 ```go
 func NewExternalSpan(ctx context.Context, name string, url string) (Span, context.Context)
@@ -192,7 +192,7 @@ func main() {
 </details>
 
 <a name="NewHTTPExternalSpan"></a>
-### func [NewHTTPExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L254>)
+### func [NewHTTPExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L258>)
 
 ```go
 func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.Header) (Span, context.Context)
@@ -201,7 +201,7 @@ func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.
 NewHTTPExternalSpan starts a span for tracing external HTTP actions. It also injects trace propagation headers so the external service can correlate the call back to this service.
 
 <a name="NewInternalSpan"></a>
-### func [NewInternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L139>)
+### func [NewInternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L140>)
 
 ```go
 func NewInternalSpan(ctx context.Context, name string) (Span, context.Context)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ const SupportPackageIsVersion1 = true
 ```
 
 <a name="ClientSpan"></a>
-## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L275>)
+## func [ClientSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L282>)
 
 ```go
 func ClientSpan(operationName string, ctx context.Context) (context.Context, oteltrace.Span)
@@ -60,7 +60,7 @@ func CloneContextValues(parent context.Context) context.Context
 Deprecated: Use [NewContextWithParentValues](<#NewContextWithParentValues>) instead.
 
 <a name="GRPCTracingSpan"></a>
-## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L281>)
+## func [GRPCTracingSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L288>)
 
 ```go
 func GRPCTracingSpan(operationName string, ctx context.Context) context.Context
@@ -96,7 +96,7 @@ func NewContextWithParentValues(parent context.Context) context.Context
 NewContextWithParentValues clones a given context values and returns a new context obj which is not affected by Cancel, Deadline etc can be used to pass context values to a new context which is not affected by the parent context cancel/deadline etc from parent
 
 <a name="Span"></a>
-## type [Span](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L45-L56>)
+## type [Span](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L46-L57>)
 
 Span defines an interface for implementing a tracing span. Consumers use this to create and annotate spans without coupling to a specific tracing backend.
 
@@ -116,7 +116,7 @@ type Span interface {
 ```
 
 <a name="NewDatastoreSpan"></a>
-### func [NewDatastoreSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L169>)
+### func [NewDatastoreSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L172>)
 
 ```go
 func NewDatastoreSpan(ctx context.Context, datastore, operation, collection string) (Span, context.Context)
@@ -154,7 +154,7 @@ func main() {
 </details>
 
 <a name="NewExternalSpan"></a>
-### func [NewExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L251>)
+### func [NewExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L258>)
 
 ```go
 func NewExternalSpan(ctx context.Context, name string, url string) (Span, context.Context)
@@ -192,7 +192,7 @@ func main() {
 </details>
 
 <a name="NewHTTPExternalSpan"></a>
-### func [NewHTTPExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L258>)
+### func [NewHTTPExternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L265>)
 
 ```go
 func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.Header) (Span, context.Context)
@@ -201,7 +201,7 @@ func NewHTTPExternalSpan(ctx context.Context, name string, url string, hdr http.
 NewHTTPExternalSpan starts a span for tracing external HTTP actions. It also injects trace propagation headers so the external service can correlate the call back to this service.
 
 <a name="NewInternalSpan"></a>
-### func [NewInternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L140>)
+### func [NewInternalSpan](<https://github.com/go-coldbrew/tracing/blob/main/tracing.go#L143>)
 
 ```go
 func NewInternalSpan(ctx context.Context, name string) (Span, context.Context)

--- a/tracing.go
+++ b/tracing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	neturl "net/url"
 	"runtime/trace"
 	"strings"
 
@@ -109,9 +110,11 @@ func (span *tracingSpan) SetQuery(query string) {
 	if span == nil {
 		return
 	}
-	span.otelSpan.SetAttributes(semconv.DBQueryText(query))
 	if span.datastore {
+		span.otelSpan.SetAttributes(semconv.DBQueryText(query))
 		span.dataSegment.ParameterizedQuery = query
+	} else {
+		span.otelSpan.SetAttributes(attribute.String("query", query))
 	}
 }
 
@@ -217,9 +220,13 @@ func buildExternalSpan(ctx context.Context, name string, url string) (*tracingSp
 		url = "http://" + name + "/" + url
 	}
 
+	serverAddr := name
+	if parsed, err := neturl.Parse(url); err == nil && parsed.Hostname() != "" {
+		serverAddr = parsed.Hostname()
+	}
 	clientSpan.SetAttributes(
 		semconv.URLFull(url),
-		semconv.ServerAddress(name),
+		semconv.ServerAddress(serverAddr),
 	)
 	txnStarted := false
 	txn := nrutil.GetNewRelicTransactionFromContext(ctx)

--- a/tracing.go
+++ b/tracing.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/metadata"
 )
@@ -108,7 +109,7 @@ func (span *tracingSpan) SetQuery(query string) {
 	if span == nil {
 		return
 	}
-	span.otelSpan.SetAttributes(toAttribute("query", query))
+	span.otelSpan.SetAttributes(semconv.DBQueryText(query))
 	if span.datastore {
 		span.dataSegment.ParameterizedQuery = query
 	}
@@ -174,9 +175,9 @@ func NewDatastoreSpan(ctx context.Context, datastore, operation, collection stri
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
 	)
 	otelSpan.SetAttributes(
-		attribute.String("store", datastore),
-		attribute.String("collection", collection),
-		attribute.String("operation", operation),
+		semconv.DBSystemNameKey.String(datastore),
+		semconv.DBCollectionName(collection),
+		semconv.DBOperationName(operation),
 	)
 
 	txnStarted := false
@@ -216,7 +217,10 @@ func buildExternalSpan(ctx context.Context, name string, url string) (*tracingSp
 		url = "http://" + name + "/" + url
 	}
 
-	clientSpan.SetAttributes(attribute.String("url", url))
+	clientSpan.SetAttributes(
+		semconv.URLFull(url),
+		semconv.ServerAddress(name),
+	)
 	txnStarted := false
 	txn := nrutil.GetNewRelicTransactionFromContext(ctx)
 	if txn == nil {


### PR DESCRIPTION
## Summary
- Datastore spans: use `db.system.name`, `db.collection.name`, `db.operation.name`, `db.query.text` per [DB semconv spec](https://opentelemetry.io/docs/specs/semconv/db/database-spans/)
- External spans: use `url.full` and `server.address` per [HTTP client semconv spec](https://opentelemetry.io/docs/specs/semconv/http/http-spans/); parse hostname from absolute URLs for accurate `server.address`
- Gate `db.query.text` behind datastore span check — non-datastore spans use generic `query` attribute to avoid semantic mismatch

## Test plan
- [x] `make test` passes with `-race`
- [x] `make build` compiles cleanly
- [ ] Deploy to staging and verify span attributes in trace backend (Grafana/Jaeger)