### PR TITLE
feat: add goleak test coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/newrelic/go-agent/v3 v3.42.0
 	go.opentelemetry.io/otel v1.42.0
 	go.opentelemetry.io/otel/trace v1.42.0
+	go.uber.org/goleak v1.3.0
 	google.golang.org/grpc v1.79.3
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-coldbrew/tracing
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/newrelic/go-agent/v3 v3.42.0

--- a/goleak_test.go
+++ b/goleak_test.go
@@ -1,0 +1,11 @@
+package tracing
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
## Summary
- Add `goleak.VerifyTestMain` to catch goroutine leaks in tests

## Test plan
- [x] `make test` passes with goleak enabled
- [x] `make lint` clean